### PR TITLE
Fix gRPC server to include runtime information

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -215,7 +215,8 @@ func (p *envoyExtAuthzGrpcServer) eval(ctx context.Context, input ast.Value, opt
 			rego.ParsedInput(input),
 			rego.Compiler(p.manager.GetCompiler()),
 			rego.Store(p.manager.Store),
-			rego.Transaction(txn))
+			rego.Transaction(txn),
+			rego.Runtime(p.manager.Info))
 
 		rs, err := rego.New(opts...).Eval(ctx)
 


### PR DESCRIPTION
The gRPC server was not supplying runtime info used by the
opa.runtime() built-in function. This change simply updates the server
to pass the runtime information term exposed by the manager.

Fixes #88

Signed-off-by: Torin Sandall <torinsandall@gmail.com>