### PR TITLE
Add support for dry-run mode

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -32,6 +32,7 @@
         envoy_ext_authz_grpc:
             addr: :9191
             query: data.istio.authz.allow
+            dry-run: false
     ```
 
 6. Run OPA

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -331,6 +331,7 @@ func testAuthzServer(customLogger plugins.Plugin) *envoyExtAuthzGrpcServer {
 		cfg: Config{
 			Addr:        ":50052",
 			Query:       query,
+			DryRun:      false,
 			parsedQuery: parsedQuery,
 		},
 		manager: m,


### PR DESCRIPTION
Initial stab at supporting dry-run mode in the opa-grpc plugin, which defaults to `false`

If this is set to true, the grpc layer will unconditionally return `true`, regardless of what the query result was. This will be used in conjunction with console decision logging to query a whole package (e.g. `data.mypackage` (instead of only supporting boolean like `data.mypackage.allow`)) so that full context of what led to the decision can be logged.

This will likely only be a short-term strategy, until something like https://github.com/open-policy-agent/opa/issues/1508 is addressed, for two reasons:
1. We are at the very first stage of trying to roll out this infrastructure, and it's good to be running in this "shadow" mode where we allow no matter what, but we log what we would have done
2. Once we have some mileage on the infrastructure and https://github.com/open-policy-agent/opa/issues/1508 is addressed, we can have more confidence in allowing actual decisions to be returned while providing the context in response headers, and we can also consider rolling out decision changes in a "canary-like" fashion wherein we roll out new policies to a light weighted percentage of requests.