### PR TITLE
Add functionality to return more attributes of the Envoy Ext Authz re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,11 @@ The OPA-Istio plugin supports the following configuration fields:
 | Field | Required | Description |
 | --- | --- | --- |
 | `plugins["envoy_ext_authz_grpc"].addr` | No | Set listening address of Envoy External Authorization gRPC server. This must match the value configured in the Envoy Filter resource. Default: `:9191`. |
-| `plugins["envoy_ext_authz_grpc"].query` | No | Specifies the name of the policy decision to query. The policy decision must be return a `boolean` value. `true` indicates the request should be allowed and `false` indicates the request should be denied. Default: `data.istio.authz.allow`. |
+| `plugins["envoy_ext_authz_grpc"].query` | No | Specifies the name of the policy decision to query. The policy decision can either be a `boolean` or an `object`. If boolean, `true` indicates the request should be allowed and `false` indicates the request should be denied. If the policy decision is an object, it **must** contain the `allowed` key set to either `true` or `false` to indicate if the request is allowed or not respectively. It can optionally contain a `headers` field to send custom headers to the downstream client or upstream. An optional `body` field can be included in the policy decision to send a response body data to the downstream client. Also an optional `http_status` field can be included to send a HTTP response status code to the downstream client other than `403 (Forbidden)`. Default: `data.istio.authz.allow`.|
+
+If the configuration does not specify the `query` field, `data.istio.authz.allow` will be considered as the default name of the policy decision to query.
+
+An example of a rule that returns an object that not only indicates if a request is allowed or not but also provides optional response headers, body and HTTP status that can be sent to the downstream client or upstream can be seen below in the [Example Policy with Object Response](#example-policy-with-object-response) section.
 
 In the [Quick Start](#quick-start) section an OPA policy is loaded via a volume-mounted ConfigMap. For production deployments, we recommend serving policy [Bundles](http://www.openpolicyagent.org/docs/bundles.html) from a remote HTTP server. For example:
 
@@ -277,6 +281,29 @@ default allow = false
 
 allow {
    input.parsed_path = ["api", "v1", "products"]
+}
+```
+
+## Example Policy with Object Response
+
+The `allow` rule in the below policy when queried generates an `object` that provides the status of the request (ie. `allowed` or `denied`) alongwith some headers, body data and HTTP status which will be included in the response that is sent back to the downstream client or upstream.
+
+```ruby
+package istio.authz
+
+default allow = {
+  "allowed": false,
+  "headers": {"x-ext-auth-allow": "no"},
+  "body": "Unauthorized Request",
+  "http_status": 301
+}
+
+allow = response {
+  input.attributes.request.http.method == "GET"
+  response := {
+    "allowed": true,
+    "headers": {"x-ext-auth-allow": "yes"}
+  }
 }
 ```
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -16,7 +16,9 @@ import (
 
 	ctx "golang.org/x/net/context"
 
+	ext_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	ext_authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	ext_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	google_rpc "github.com/gogo/googleapis/google/rpc"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/metrics"
@@ -26,6 +28,7 @@ import (
 	"github.com/open-policy-agent/opa/server"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/util"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
@@ -39,7 +42,7 @@ type evalResult struct {
 	revision   string
 	decisionID string
 	txnID      uint64
-	decision   bool
+	decision   interface{}
 	metrics    metrics.Metrics
 }
 
@@ -61,6 +64,7 @@ func Validate(m *plugins.Manager, bs []byte) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	cfg.parsedQuery = parsedQuery
 
 	return &cfg, nil
@@ -153,14 +157,58 @@ func (p *envoyExtAuthzGrpcServer) Check(ctx ctx.Context, req *ext_authz.CheckReq
 		return nil, err
 	}
 
-	status := int32(google_rpc.PERMISSION_DENIED)
+	resp := &ext_authz.CheckResponse{}
 
-	if result.decision {
-		status = int32(google_rpc.OK)
-	}
+	switch decision := result.decision.(type) {
+	case bool:
+		status := int32(google_rpc.PERMISSION_DENIED)
+		if decision {
+			status = int32(google_rpc.OK)
+		}
 
-	resp := &ext_authz.CheckResponse{
-		Status: &google_rpc.Status{Code: status},
+		resp.Status = &google_rpc.Status{Code: status}
+
+	case map[string]interface{}:
+		status, err := getResponseStatus(decision)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get response status")
+		}
+
+		resp.Status = &google_rpc.Status{Code: status}
+
+		responseHeaders, err := getResponseHeaders(decision)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get response headers")
+		}
+
+		if status == int32(google_rpc.OK) {
+			resp.HttpResponse = &ext_authz.CheckResponse_OkResponse{
+				OkResponse: &ext_authz.OkHttpResponse{
+					Headers: responseHeaders,
+				},
+			}
+		} else {
+			body, err := getResponseBody(decision)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get response body")
+			}
+
+			httpStatus, err := getResponseHTTPStatus(decision)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get response http status")
+			}
+
+			resp.HttpResponse = &ext_authz.CheckResponse_DeniedResponse{
+				DeniedResponse: &ext_authz.DeniedHttpResponse{
+					Headers: responseHeaders,
+					Body:    body,
+					Status:  httpStatus,
+				},
+			}
+		}
+
+	default:
+		return nil, fmt.Errorf("illegal value for policy evaluation result: %T", decision)
 	}
 
 	err = p.log(ctx, input, result, err)
@@ -193,7 +241,6 @@ func (p *envoyExtAuthzGrpcServer) eval(ctx context.Context, input ast.Value, opt
 	err := storage.Txn(ctx, p.manager.Store, storage.TransactionParams{}, func(txn storage.Transaction) error {
 
 		var err error
-		var decision, ok bool
 
 		result.revision, err = getRevision(ctx, p.manager.Store, txn)
 		if err != nil {
@@ -228,11 +275,11 @@ func (p *envoyExtAuthzGrpcServer) eval(ctx context.Context, input ast.Value, opt
 			return err
 		} else if len(rs) == 0 {
 			return fmt.Errorf("undefined decision")
-		} else if decision, ok = rs[0].Expressions[0].Value.(bool); !ok || len(rs) > 1 {
-			return fmt.Errorf("non-boolean decision")
+		} else if len(rs) > 1 {
+			return fmt.Errorf("multiple evaluation results")
 		}
 
-		result.decision = decision
+		result.decision = rs[0].Expressions[0].Value
 		return nil
 	})
 
@@ -261,6 +308,111 @@ func (p *envoyExtAuthzGrpcServer) log(ctx context.Context, input interface{}, re
 	}
 
 	return plugin.Log(ctx, info)
+}
+
+// getResponseStatus returns the status of the evaluation.
+// The status is determined by the "allowed" key in the evaluation
+// result and is represented as a boolean value. If the key is missing, an
+// error will be returned.
+func getResponseStatus(result map[string]interface{}) (int32, error) {
+	status := int32(google_rpc.PERMISSION_DENIED)
+
+	var decision, ok bool
+	var val interface{}
+
+	if val, ok = result["allowed"]; !ok {
+		return 0, fmt.Errorf("unable to determine evaluation result due to missing \"allowed\" key")
+	}
+
+	if decision, ok = val.(bool); !ok {
+		return 0, fmt.Errorf("type assertion error")
+	}
+
+	if decision {
+		status = int32(google_rpc.OK)
+	}
+
+	return status, nil
+}
+
+func getResponseHeaders(result map[string]interface{}) ([]*ext_core.HeaderValueOption, error) {
+	var ok bool
+	var val interface{}
+	var headers map[string]interface{}
+
+	responseHeaders := []*ext_core.HeaderValueOption{}
+
+	if val, ok = result["headers"]; !ok {
+		return responseHeaders, nil
+	}
+
+	if headers, ok = val.(map[string]interface{}); !ok {
+		return nil, fmt.Errorf("type assertion error")
+	}
+
+	for key, value := range headers {
+		var headerVal string
+		if headerVal, ok = value.(string); !ok {
+			return nil, fmt.Errorf("type assertion error")
+		}
+
+		headerValue := &ext_core.HeaderValue{
+			Key:   key,
+			Value: headerVal,
+		}
+
+		headerValueOption := &ext_core.HeaderValueOption{
+			Header: headerValue,
+		}
+
+		responseHeaders = append(responseHeaders, headerValueOption)
+	}
+	return responseHeaders, nil
+}
+
+func getResponseBody(result map[string]interface{}) (string, error) {
+	var ok bool
+	var val interface{}
+	var body string
+
+	if val, ok = result["body"]; !ok {
+		return "", nil
+	}
+
+	if body, ok = val.(string); !ok {
+		return "", fmt.Errorf("type assertion error")
+	}
+
+	return body, nil
+}
+
+func getResponseHTTPStatus(result map[string]interface{}) (*ext_type.HttpStatus, error) {
+	var ok bool
+	var val interface{}
+	var statusCode json.Number
+
+	status := &ext_type.HttpStatus{}
+
+	if val, ok = result["http_status"]; !ok {
+		return nil, nil
+	}
+
+	if statusCode, ok = val.(json.Number); !ok {
+		return nil, fmt.Errorf("type assertion error")
+	}
+
+	httpStatusCode, err := statusCode.Int64()
+	if err != nil {
+		return nil, fmt.Errorf("error converting JSON number to int: %v", err)
+	}
+
+	if _, ok := ext_type.StatusCode_name[int32(httpStatusCode)]; !ok {
+		return nil, fmt.Errorf("Invalid HTTP status code %v", httpStatusCode)
+	}
+
+	status.Code = ext_type.StatusCode(int32(httpStatusCode))
+
+	return status, nil
 }
 
 func uuid4() (string, error) {


### PR DESCRIPTION
…sponse.

The PR adds support for the `response_query` config field which allows the authorization service to return the status of request (ie. `allowed` or `denied`) alongwith some headers and body data to send back to the downstream client or upstream.

See: https://github.com/open-policy-agent/opa/issues/1508

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>