### PR TITLE
Add a flag for dry-run mode, which configures Opa …

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ The OPA-Istio plugin supports the following configuration fields:
 | --- | --- | --- |
 | `plugins["envoy_ext_authz_grpc"].addr` | No | Set listening address of Envoy External Authorization gRPC server. This must match the value configured in the Envoy Filter resource. Default: `:9191`. |
 | `plugins["envoy_ext_authz_grpc"].query` | No | Specifies the name of the policy decision to query. The policy decision can either be a `boolean` or an `object`. If boolean, `true` indicates the request should be allowed and `false` indicates the request should be denied. If the policy decision is an object, it **must** contain the `allowed` key set to either `true` or `false` to indicate if the request is allowed or not respectively. It can optionally contain a `headers` field to send custom headers to the downstream client or upstream. An optional `body` field can be included in the policy decision to send a response body data to the downstream client. Also an optional `http_status` field can be included to send a HTTP response status code to the downstream client other than `403 (Forbidden)`. Default: `data.istio.authz.allow`.|
+| `plugins["envoy_ext_authz_grpc"].dry-run` | No | Configures the Envoy External Authorization gRPC server to unconditionally return an `ext_authz.CheckResponse.Status` of `google_rpc.Status{Code: google_rpc.OK}`. Default: `false`. |
 
 If the configuration does not specify the `query` field, `data.istio.authz.allow` will be considered as the default name of the policy decision to query.
+
+The `dry-run` parameter is provided to enable you to test out new policies. You can set `dry-run: true` which will unconditionally allow requests. Decision logs can be monitored to see what "would" have happened. This is especially useful for initial integration of OPA or when policies undergo large refactoring.
 
 An example of a rule that returns an object that not only indicates if a request is allowed or not but also provides optional response headers, body and HTTP status that can be sent to the downstream client or upstream can be seen below in the [Example Policy with Object Response](#example-policy-with-object-response) section.
 
@@ -156,8 +159,9 @@ bundle:
   service: bundle_service
 plugins:
     envoy_ext_authz_grpc:
-        addr: :9191
-        query: data.istio.authz.allow
+        addr:    :9191
+        query:   data.istio.authz.allow
+        dry-run: false
 ```
 
 ## Example Policy

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -30,8 +30,9 @@
     ```yaml
     plugins:
         envoy_ext_authz_grpc:
-            addr: :9191
-            query: data.istio.authz.allow
+            addr:    :9191
+            query:   data.istio.authz.allow
+            dry-run: false
     ```
 
 6. Run OPA


### PR DESCRIPTION
…to unconditionally return 
`ext_authz.CheckResponse.Status` => `google_rpc.Status{Code: google_rpc.OK}`
`ext_authz.CheckResponse.HttpReponse` => `ext_authz.OkHttpResponse`

This will allow for testing new policies without impacting live traffic. The intended use case is to run with `dry-run: true` and watch decision logs to see what "would" have happened.