### PR TITLE
Enable Go module support

### DIFF
--- a/build/update-opa-version.sh
+++ b/build/update-opa-version.sh
@@ -17,7 +17,7 @@ if [ $# -eq 0 ]
 fi
 
 # Update OPA version
-go get github.com/open-policy-agent/opa@$1
+env GO111MODULE=on go get github.com/open-policy-agent/opa@$1
 
 # Check if OPA version has changed
 git status |  grep  go.mod
@@ -32,7 +32,7 @@ if [ $? -eq 0 ]; then
   sed -i "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-istio\"\,/;}" quick_start.yaml
 
   # update vendor
-  go mod vendor
+  env GO111MODULE=on go mod vendor
 
   # reverse changes to golang tools
   # Issue: https://github.com/golang/go/issues/25922 and https://github.com/golang/go/issues/30515


### PR DESCRIPTION
If the project exists in the GOPATH and GO111MODULE=auto, we need to explicitly set GO111MODULE=on to enable module behavior.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>