### PR TITLE
Set denied status when it exists.

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -208,17 +208,22 @@ func (p *envoyExtAuthzGrpcServer) Check(ctx ctx.Context, req *ext_authz.CheckReq
 				return nil, errors.Wrap(err, "failed to get response body")
 			}
 
+			deniedResponse := &ext_authz.DeniedHttpResponse{
+				Headers: responseHeaders,
+				Body:    body,
+			}
+
 			httpStatus, err := getResponseHTTPStatus(decision)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get response http status")
 			}
 
+			if httpStatus != nil {
+				deniedResponse.Status = httpStatus
+			}
+
 			resp.HttpResponse = &ext_authz.CheckResponse_DeniedResponse{
-				DeniedResponse: &ext_authz.DeniedHttpResponse{
-					Headers: responseHeaders,
-					Body:    body,
-					Status:  httpStatus,
-				},
+				DeniedResponse: deniedResponse,
 			}
 		}
 


### PR DESCRIPTION
The denied status is a required field that should be set when a valid http satus is provided. Setting this to nil can cause Envoy to return an Unknown error on a denied request.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>