### PR TITLE
Default to logging in json format. 

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -52,6 +52,8 @@ type evalResult struct {
 // configuration and returns a configuration value that can be used to
 // instantiate the plugin.
 func Validate(m *plugins.Manager, bs []byte) (*Config, error) {
+	// Default to logging consistently with the default in Opa server
+	logrus.SetFormatter(&logrus.JSONFormatter{})
 
 	cfg := Config{
 		Addr:   defaultAddr,


### PR DESCRIPTION
This matches the main opa server default log format, and is a stop-gap until https://github.com/open-policy-agent/opa/issues/1580 is addressed.