### PR TITLE
travis: Create and push latest tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ after_success:
 - if is_travis_push_env; then docker login -u $DOCKER_USER -p $DOCKER_PASSWORD; fi
 - if is_travis_push_env; then make image-quick; fi
 - if is_travis_push_env; then make push; fi
+- if is_travis_push_env; then make tag-latest; fi
+- if is_travis_push_env; then make push-latest; fi

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,12 @@ image-quick:
 push:
 	docker push $(IMAGE):$(VERSION)
 
+tag-latest:
+	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest-istio
+
+push-latest:
+	docker push $(IMAGE):latest-istio
+
 update-opa:
 	@./build/update-opa-version.sh $(TAG)
 


### PR DESCRIPTION
These changes update the travis build to create and push latest tags for opa-istio images. This is needed to support the opa-istio image version in upcoming OPA-Envoy tutorial for the edge version of the OPA docs.

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>