### PR TITLE
Downgrade request logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ update-opa:
 	@./build/update-opa-version.sh $(TAG)
 
 test: generate
-	$(DISABLE_CGO) $(GO) test $(PACKAGES)
+	$(DISABLE_CGO) $(GO) test -bench=. $(PACKAGES)
 
 clean:
 	rm -f .Dockerfile_*

--- a/internal/internal_bench_test.go
+++ b/internal/internal_bench_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019 The OPA Authors. All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+package internal
+
+import (
+	"context"
+	"testing"
+
+	ext_authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	google_rpc "github.com/gogo/googleapis/google/rpc"
+	"github.com/open-policy-agent/opa/util"
+)
+
+func BenchmarkCheck(b *testing.B) {
+
+	var req ext_authz.CheckRequest
+	if err := util.Unmarshal([]byte(exampleAllowedRequest), &req); err != nil {
+		panic(err)
+	}
+
+	server := testAuthzServer(&testPlugin{}, false)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		output, err := server.Check(ctx, &req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if output.Status.Code != int32(google_rpc.OK) {
+			b.Fatal("Expected request to be allowed but got:", output)
+		}
+	}
+}


### PR DESCRIPTION
These changes change request logging from Info to Debug. Earlier the full request was looged at Info which is unnecessary especially when the console decision logger can be used instead.

Fixes #open-policy-agent/opa/issues/1554

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>