### PR TITLE
Add required stat_prefix on Envoy authz network filter

### DIFF
--- a/quick_start.yaml
+++ b/quick_start.yaml
@@ -36,6 +36,7 @@ spec:
     filterType: NETWORK
     filterName: "envoy.ext_authz"
     filterConfig:
+      stat_prefix: "ext_authz"
       grpc_service:
         google_grpc:
           target_uri: 127.0.0.1:9191


### PR DESCRIPTION
Hello,

This is to fix the following error I get whenever I try to apply the `quick_start.yaml` as is:

```
Proto constraint validation failed (ExtAuthzValidationError.StatPrefix: ["value length must be at least " '\x01' " bytes"]): grpc_service {
  google_grpc {
    target_uri: "127.0.0.1:9191"
    stat_prefix: "ext_authz"
  }
}
, virtualInbound: Proto constraint validation failed (ExtAuthzValidationError.StatPrefix: ["value length must be at least " '\x01' " bytes"]): grpc_service {
  google_grpc {
    target_uri: "127.0.0.1:9191"
    stat_prefix: "ext_authz"
  }
}
```

As per the [docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/ext_authz/v2/ext_authz.proto#network-external-authorization), `stat_prefix` is required on the same level as `grpc_service` in the network filter part of the `EnvoyFilter` object. 

In case anyone is curious, I am using Istio 1.3.1.