### PR TITLE
Update the package path used in the LDFLAGS to set the version inform…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,10 @@ BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)
 BUILD_HOSTNAME := $(shell ./build/get-build-hostname.sh)
 
-OPA_VENDOR := vendor/github.com/open-policy-agent/opa
-
-LDFLAGS := "-X github.com/open-policy-agent/opa-istio-plugin/$(OPA_VENDOR)/version.Version=$(VERSION) \
-	-X github.com/open-policy-agent/opa-istio-plugin/$(OPA_VENDOR)/version.Vcs=$(BUILD_COMMIT) \
-	-X github.com/open-policy-agent/opa-istio-plugin/$(OPA_VENDOR)/version.Timestamp=$(BUILD_TIMESTAMP) \
-	-X github.com/open-policy-agent/opa-istio-plugin/$(OPA_VENDOR)/version.Hostname=$(BUILD_HOSTNAME)"
+LDFLAGS := "-X github.com/open-policy-agent/opa/version.Version=$(VERSION) \
+	-X github.com/open-policy-agent/opa/version.Vcs=$(BUILD_COMMIT) \
+	-X github.com/open-policy-agent/opa/version.Timestamp=$(BUILD_TIMESTAMP) \
+	-X github.com/open-policy-agent/opa/version.Hostname=$(BUILD_HOSTNAME)"
 
 GO15VENDOREXPERIMENT := 1
 export GO15VENDOREXPERIMENT


### PR DESCRIPTION
…ation correctly with go 1.13. Fixes open-policy-agent/opa#2374

See open-policy-agent/opa#2374 for more details and a demonstration of this fix working

cc @ashutosh-narkar FYI