### PR TITLE
Update health probes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ opa_*
 .Dockerfile_*
 _release
 site.tar.gz
+*.bak
 
 # runtime artifacts
 policies

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ update-quickstart-version:
 	sed -i "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:latest-istio\"\,/;}" quick_start.yaml
 
 test: generate
-	$(DISABLE_CGO) $(GO) test -bench=. $(PACKAGES)
+	$(DISABLE_CGO) $(GO) test -v -bench=. $(PACKAGES)
 
 test-e2e:
 	bats -t test/bats/test.bats

--- a/README.md
+++ b/README.md
@@ -116,11 +116,17 @@ containers:
   args:
   - run
   - --server
+  - --addr=localhost:8181
+  - --diagnostic-addr=0.0.0.0:8282
   - --config-file=/config/config.yaml
+  livenessProbe: 
+    httpGet:
+      path: /health?plugins
+      port: 8282
   readinessProbe: 
     httpGet:
-      path: /health?bundles
-      port: 8181
+      path: /health?plugins
+      port: 8282
 ```
 
 The OPA-Istio configuration file should be volume mounted into the container. Add the following volume to your Kubernetes Deployments:

--- a/build/get-opa-version.sh
+++ b/build/get-opa-version.sh
@@ -4,4 +4,6 @@
 # The script also trims whitespaces.
 
 SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
-grep "open-policy-agent/opa" $SCRIPT_DIR/../go.mod | tail -1 | cut -d' ' -f 2 | xargs | cut -c 2-
+
+# Ignore the "module" definition and any "replace" directives
+grep "open-policy-agent/opa" $SCRIPT_DIR/../go.mod | grep -vE 'module|replace' | tail -1 | cut -d' ' -f 2 | xargs | cut -c 2-

--- a/build/update-opa-version.sh
+++ b/build/update-opa-version.sh
@@ -26,10 +26,11 @@ if [ $? -eq 0 ]; then
   tag=$(echo $1 | cut -c 2-)   # Remove 'v' in Tag. Eg. v0.8.0 -> 0.8.0
 
   # update plugin image version in README
-  sed -i "s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-istio/" README.md
+  sed -i.bak "s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-istio/" README.md && rm README.md.bak
 
   # update plugin image version in quick_start.yaml
-  sed -i "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-istio\"\,/;}" quick_start.yaml
+  sed -i.bak "/opa_container/{N;s/openpolicyagent\/opa:.*/openpolicyagent\/opa:$tag-istio\"\,/;}" quick_start.yaml && rm quick_start.yaml.bak
+  sed -i.bak "s/image: openpolicyagent\/opa:.*/image: openpolicyagent\/opa:$tag/" quick_start.yaml quick_start.yaml && rm quick_start.yaml.bak
 
   # update vendor
   env GO111MODULE=on go mod vendor

--- a/cmd/opa-istio-plugin/main.go
+++ b/cmd/opa-istio-plugin/main.go
@@ -30,7 +30,7 @@ func (Factory) Validate(m *plugins.Manager, config []byte) (interface{}, error) 
 func main() {
 
 	runtime.RegisterPlugin("envoy.ext_authz.grpc", Factory{}) // for backwards compatibility
-	runtime.RegisterPlugin("envoy_ext_authz_grpc", Factory{})
+	runtime.RegisterPlugin(internal.PluginName, Factory{})
 
 	if err := cmd.RootCommand.Execute(); err != nil {
 		fmt.Println(err)

--- a/quick_start.yaml
+++ b/quick_start.yaml
@@ -179,7 +179,7 @@ spec:
       name: admission-controller
     spec:
       containers:
-        - image: openpolicyagent/opa:0.10.3
+        - image: openpolicyagent/opa:0.19.2
           name: opa
           ports:
           - containerPort: 443

--- a/quick_start.yaml
+++ b/quick_start.yaml
@@ -105,6 +105,8 @@ data:
         "run",
         "--server",
         "--config-file=/config/config.yaml",
+        "--addr=localhost:8181",
+        "--diagnostic-addr=0.0.0.0:8282",
         "/policy/policy.rego",
       ],
       "volumeMounts": [{
@@ -116,10 +118,16 @@ data:
       }],
       "readinessProbe": {
         "httpGet": {
-          "path": "/health?bundles",
-          "port": 8181,
+          "path": "/health?plugins",
+          "port": 8282,
         },
       },
+      "livenessProbe": {
+        "httpGet": {
+          "path": "/health?plugins",
+          "port": 8282,
+        },
+      }
     }
 
     opa_config_volume = {
@@ -182,6 +190,20 @@ spec:
           - "--tls-private-key-file=/certs/tls.key"
           - "--addr=0.0.0.0:443"
           - "/policies/inject.rego"
+          livenessProbe:
+            httpGet:
+              path: /health?plugins
+              scheme: HTTPS
+              port: 443
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health?plugins
+              scheme: HTTPS
+              port: 443
+            initialDelaySeconds: 5
+            periodSeconds: 5
           volumeMounts:
             - readOnly: true
               mountPath: /certs


### PR DESCRIPTION
This combines a few changes related to health probes for the plugins.

* Updates to using the new `--diagnostic-addr` OPA option to serve /health on a separate port
* Adds/modifies readiness and liveness probes to use the alternate port in the quickstart and readme
* Updates the health check URL to use `?plugins` and updates the gRPC plugin to report its status to the OPA plugin manager.

There are a couple random fixes included that I found along the way while working on the changes and testing them all out.