### PR TITLE
Update Envoy Filter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ availability) in order to perform the authorization check.
 
 ## Quick Start
 
-This section assumes you are testing with Istio v1.1.0 or later.
+This section assumes you are testing with Istio v1.5.0 or later.
 
 This section assumes you have Istio deployed on top of Kubernetes. See Istio's [Quick Start](https://istio.io/docs/setup/kubernetes/install/kubernetes/) page to get started.
 

--- a/quick_start.yaml
+++ b/quick_start.yaml
@@ -7,40 +7,36 @@ metadata:
   name: ext-authz
   namespace: istio-system
 spec:
-  filters:
-  - insertPosition:
-      index: FIRST
-    listenerMatch:
-      listenerType: SIDECAR_INBOUND
-      listenerProtocol: HTTP
-    filterType: HTTP
-    filterName: "envoy.ext_authz"
-    filterConfig:
-      with_request_body:
-        max_request_bytes: 8192
-        allow_partial_message: true
-      grpc_service:
-        # NOTE(tsandall): when this was tested with the envoy_grpc client the gRPC
-        # server was receiving check requests over HTTP 1.1. The gRPC server in
-        # OPA-Istio would immediately close the connection and log that a bogus
-        # preamble was sent by the client (it expected HTTP 2). Switching to the
-        # google_grpc client resolved this issue.
-        google_grpc:
-          target_uri: 127.0.0.1:9191
-          stat_prefix: "ext_authz"
-  - insertPosition:
-      index: FIRST
-    listenerMatch:
-      listenerType: SIDECAR_INBOUND
-      listenerProtocol: TCP
-    filterType: NETWORK
-    filterName: "envoy.ext_authz"
-    filterConfig:
-      stat_prefix: "ext_authz"
-      grpc_service:
-        google_grpc:
-          target_uri: 127.0.0.1:9191
-          stat_prefix: "ext_authz"
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.ext_authz
+          typed_config:
+            "@type": "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthz"
+            status_on_error:
+              code: ServiceUnavailable
+            with_request_body:
+              max_request_bytes: 8192
+              allow_partial_message: true
+            grpc_service:
+              # NOTE(tsandall): when this was tested with the envoy_grpc client the gRPC
+              # server was receiving check requests over HTTP 1.1. The gRPC server in
+              # OPA-Istio would immediately close the connection and log that a bogus
+              # preamble was sent by the client (it expected HTTP 2). Switching to the
+              # google_grpc client resolved this issue.
+              google_grpc:
+                target_uri: 127.0.0.1:9191
+                stat_prefix: "ext_authz"
 ---
 ############################################################
 # Namespace for cluster-wide OPA-Istio components.


### PR DESCRIPTION
This commit updates the configuration of the Envoy Filter CRD
supported by Istio v1.5.0 and later.

It adds a http external authroization filter in the http
connection manager filter chain. The filter will authorize a request
before the envoy router filter forwards it.

Thanks @blastdan for working on the initial version of the filter.

Fixes: https://github.com/open-policy-agent/opa/issues/2454

Signed-off-by: Ashutosh Narkar <anarkar4387@gmail.com>